### PR TITLE
update version to 2.4.5 and support latest IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     // Kotlin support
     id("org.jetbrains.kotlin.jvm") version "1.8.0"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.12.0"
+    id("org.jetbrains.intellij") version "1.16.1"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.0.0"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ pluginGroup=cn.neday.excavator
 pluginName=Flutter-Toolkit
 pluginRepositoryUrl=https://github.com/nEdAy/Flutter-Toolkit
 # SemVer format -> https://semver.org
-pluginVersion=2.4.4
+pluginVersion=2.4.5
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=213
-pluginUntilBuild=223.*
+pluginUntilBuild=232.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
 platformVersion=2021.3.3


### PR DESCRIPTION
Minimal changes needed to support the latest IntelliJ IDE, including Android Studio Hedgehog.

If you can't wait for the PR to be merged, you can always checkout my fork on your local machine, and run `./gradlew buildPlugin`

and install the .zip file generated in folder `build/dependencies` in your IntelliJ IDE